### PR TITLE
Update y2025

### DIFF
--- a/workshop-IADPSRM/_toc.yml
+++ b/workshop-IADPSRM/_toc.yml
@@ -8,6 +8,7 @@ options:  # The options key will be applied to all chapters, but not sub-section
   numbered: False
 
 chapters:
+- file: years/y2025
 - file: years/y2024
 - file: years/y2023
 - file: years/y2022

--- a/workshop-IADPSRM/years/y2025.md
+++ b/workshop-IADPSRM/years/y2025.md
@@ -1,0 +1,139 @@
+# BioImage Analysis and Data Processing Workshop 2025
+
+**Date:** June 30 – July 4, 2025  
+**Location:** Room B311 - VMCF Microscopy Facility, Vinicna 7, Prague, Czechia  
+**Form:** Hybrid form of presentations; hands-on sessions are in-person only  
+**Time Zone:** All times are in CEST (GMT+2)
+
+---
+
+## Program at a Glance
+
+- **Day 1:** Deconvolution and ThunderSTORM  
+- **Day 2:** CellPose and TrackMate  
+- **Day 3:** Napari  
+- **Day 4:** mesoSPIM + Leica AIVIA  
+- **Day 5:** Affordable microscopes based on 3D printing and smartphones + Bioimage analysis community
+
+---
+
+## Full Program
+
+### Day 1
+
+**10:00 – 11:00**  
+Registration (outside Room B332)  
+*Optional: software installation on your own laptops*
+
+**11:00 – 11:15**  
+Welcome note from VMCF  
+- Miroslav Hyliš, Ph.D.  
+- Martin Schätz, Ph.D.  
+- Zuzana Burdíková, Ph.D.
+
+**11:25 – 12:00**  
+*Introduction to super-resolution microscopy*  
+_Zuzana Burdíková, Ph.D._  
+- Image Formation in Fluorescence Microscopy  
+- Resolution and Noise  
+- Single-molecule localization microscopy (STORM, PALM, DNA-PAINT, …)  
+- Structured Illumination Microscopy (SIM)
+
+**12:00 – 13:20**  
+Lunch
+
+**13:20 – 14:00**  
+*Deconvolution of optical microscopy images*  
+_Prof. Rainer Heintzmann, IPHT, Jena_
+
+**14:00 – 14:10**  
+Coffee break
+
+**14:10 – 14:50**  
+*Introduction to Image processing in FIJI, ImageJ*  
+_Karel Stepka, Ph.D._  
+- Two-channel colocalization  
+- p-Value of colocalization, data filtering  
+- Quantitative analysis  
+- Data visualization, 3D visualization  
+- Image export
+**14:50 – 15:10**  
+Coffee break
+
+**15:10 – 15:50**  
+*ThunderSTORM software Introduction*  
+_Zdenek Svindrych, Ph.D._  
+- Rationale and features
+**16:00 – 17:00**  
+*ThunderSTORM software hands-on*  
+_Zdenek Svindrych, Ph.D._  
+- Installation  
+- Processing 2D and 3D STORM datasets
+
+---
+
+### Day 2
+
+**10:00 – 12:00**  
+*CellPose*  
+- Introduction, installation  
+- Running pretrained/custom models  
+- Model retraining  
+- [Cellpose model cheatsheet](https://doi.org/10.6084/m9.figshare.24441214.v2)
+
+*CellPose segmentation + Tracking*
+
+---
+
+### Day 3
+
+**10:00 – 12:00**  
+*Napari Morning Session*  
+_Marcelo Leomil Zoccoler, Ph.D. (TU Dresden)_
+
+**12:00 – 13:00**  
+Lunch
+
+**13:00 – 16:00**  
+*Napari Afternoon Session*  
+_Marcelo Leomil Zoccoler, Ph.D. & Martin Schätz, Ph.D._
+
+---
+
+### Day 4
+
+**10:00 – 12:00**  
+*Benchtop mesoSPIM: open-source light-sheet microscope*  
+_Marco Garbelli, Ph.D._  
+- Project introduction  
+- Remote demo  
+- Data visualization in Fiji/BigStitcher and 3DScript
+
+**12:00 – 13:00**  
+Lunch
+
+**13:00 – 14:00**  
+*Introduction to AIVIA analysis from Leica Microsystems*  
+- AIVIA overview  
+- LAS X + AIVIA Rare Events  
+- Adaptive deconvolution
+
+**14:00 – 16:00**  
+*Hands-on session on AIVIA online*  
+- License installation  
+- Demo data showcase  
+- User data testing
+
+---
+
+### Day 5
+
+**10:00 – 11:00**  
+*Affordable microscopes based on 3D-printing and smartphones*  
+_Prof. Rainer Heintzmann, IPHT, Jena_
+
+**11:00 – 11:30**  
+*Image analysis communities*  
+_Martin Schätz, Ph.D._
+
+---


### PR DESCRIPTION
This pull request updates the workshop's table of contents and adds a detailed program for the BioImage Analysis and Data Processing Workshop 2025. The changes include adding the 2025 workshop to the `_toc.yml` file and introducing a comprehensive schedule in the `years/y2025.md` file.

### Updates to the workshop table of contents:
* Added the 2025 workshop entry (`years/y2025`) to the `_toc.yml` file, replacing the 2024 entry.

### Addition of the 2025 workshop program:
* Created a new file, `years/y2025.md`, containing the full schedule for the BioImage Analysis and Data Processing Workshop 2025. The program includes dates, location, format, and a detailed breakdown of sessions across five days.